### PR TITLE
Update to Elasticsearch 6.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Time series aggregation for flow records.
 
 |   Drift Plugin  | Elasticsearch     | Release date |
 |-----------------|-------------------|:------------:|
-| 1.0.0           | 6.1.1             |  TBD         |
+| 1.0.0           | 6.2.2             |  TBD         |
 
 
 ## Overview

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>6.1.1</elasticsearch.version>
+        <elasticsearch.version>6.2.2</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
@@ -18,14 +18,14 @@
     </dependencySets>
     <fileSets>
       <fileSet>
-        <outputDirectory>/</outputDirectory>
+        <outputDirectory>/elasticsearch/</outputDirectory>
         <includes>
           <include>LICENSE.txt</include>
         </includes>
       </fileSet>
       <fileSet>
         <directory>src/main/resources</directory>
-        <outputDirectory>/</outputDirectory>
+        <outputDirectory>/elasticsearch/</outputDirectory>
         <includes>
           <include>plugin-descriptor.properties</include>
         </includes>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -12,6 +12,8 @@
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
                 <exclude>org.elasticsearch:elasticsearch</exclude>
+                <exclude>com.vividsolutions:jts</exclude>
+                <exclude>org.locationtech.spatial4j:spatial4j</exclude>
                 <exclude>log4j:log4j</exclude>
             </excludes>
         </dependencySet>

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -22,7 +22,7 @@
 description=The Drift plugin exposes additional aggregations for analysis of Netflow data.
 #
 # 'version': plugin's version
-version=6.1.1
+version=6.2.2
 #
 # 'name': the plugin name
 name=drift
@@ -37,7 +37,7 @@ classname=org.opennms.elasticsearch.plugin.DriftPlugin
 java.version=1.8
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=6.1.1
+elasticsearch.version=6.2.2
 ### optional elements for plugins:
 #
 # 'has.native.controller': whether or not the plugin has a native controller


### PR DESCRIPTION
This updates to Elasticsearch 6.2.2 and also fixes the plugin `.zip` file so it has an `elasticsearch/` directory prefix inside, so `elasticsearch-plugin install` doesn't complain about it.