### PR TITLE
HZN-1255: build RPM packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       - run:
+          name: Install RPM
+          command: sudo apt-get update; sudo apt-get install rpm
+
+      - run:
           name: Run the tests
           command: |
             mvn test integration-test
@@ -49,6 +53,9 @@ jobs:
 
       - store_artifacts:
           path: target/releases
+
+      - store_artifacts:
+          path: target/rpm/elasticsearch-drift-plugin/RPMS/noarch
 
       - persist_to_workspace:
           root: /home/circleci

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,76 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+	    <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>rpm-maven-plugin</artifactId>
+                    <version>2.1.5</version>
+                    <executions>
+                        <execution>
+                            <id>generate-rpm</id>
+                            <goals>
+                                <goal>rpm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <summary>Time series aggregation for flow records in Elasticsearch</summary>
+                        <description>This plugin provides a new aggregation function proportional_sum that can be used to
+group documents that contain a date range into multiple buckets, and calculate a sum
+on a per bucket basis using a ratio that is proportional to the range of time in which
+the document spent in that bucket.
+
+This aggregation function behaves like a hybrid of both the Metrics and Bucket type
+aggregations since we both create buckets and calculate a new metric.</description>
+                        <license>Apache License, Version 2.0</license>
+                        <group>Applications/System</group>
+                        <prefix>/usr/share/elasticsearch/plugins</prefix>
+                        <defaultDirmode>755</defaultDirmode>
+                        <defaultFilemode>644</defaultFilemode>
+                        <defaultUsername>root</defaultUsername>
+                        <defaultGroupname>wheel</defaultGroupname>
+                        <defineStatements>
+                            <!-- <defineStatement>_unpackaged_files_terminate_build 0</defineStatement> -->
+                        </defineStatements>
+                        <requires>
+                            <require>elasticsearch = ${elasticsearch.version}</require>
+                        </requires>
+                        <mappings>
+                            <mapping>
+                                <directory>/usr/share/elasticsearch/plugins/drift</directory>
+                                <sources>
+                                    <source><location>target/classes/plugin-descriptor.properties</location></source>
+                                </sources>
+                            </mapping>
+                            <mapping>
+                                <directory>/usr/share/elasticsearch/plugins/drift</directory>
+                                <sources>
+                                    <source><location>target/${project.name}-${project.version}.jar</location></source>
+                                </sources>
+                            </mapping>
+                            <mapping>
+                                <directory>/usr/share/elasticsearch/plugins/drift</directory>
+                                <dependency>
+                                    <includes>
+                                        <include>org.elasticsearch.plugin:aggs-matrix-stats-client</include>
+                                    </includes>
+                                </dependency>
+                            </mapping>
+                            <mapping>
+                                <directory>/usr/share/doc/elasticsearch-drift-plugin</directory>
+                                <documentation>true</documentation>
+                                <sources>
+                                    <source><location>LICENSE.txt</location></source>
+                                    <source><location>README.md</location></source>
+                                </sources>
+                            </mapping>
+                        </mappings>
+                    </configuration>
+                </plugin>
+            </plugins>
+	</pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -155,6 +225,42 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>build.rpms.usr</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>/usr/bin/rpmbuild</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build.rpms.usr.clocal</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>/usr/local/bin/rpmbuild</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
       <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/filtered-resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/filtered-resources/plugin-descriptor.properties
+++ b/src/main/filtered-resources/plugin-descriptor.properties
@@ -22,7 +22,7 @@
 description=The Drift plugin exposes additional aggregations for analysis of Netflow data.
 #
 # 'version': plugin's version
-version=6.1.1
+version=${project.version}
 #
 # 'name': the plugin name
 name=drift
@@ -37,7 +37,7 @@ classname=org.opennms.elasticsearch.plugin.DriftPlugin
 java.version=1.8
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=6.1.1
+elasticsearch.version=${elasticsearch.version}
 ### optional elements for plugins:
 #
 # 'has.native.controller': whether or not the plugin has a native controller


### PR DESCRIPTION
This PR adds RPM-building support using a profile. The profile is activated if `rpmbuild` is found in `/usr/bin` or `/usr/local/bin`.