### PR TITLE
fix plugin .zip to contain an /elasticsearch/ path

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
@@ -18,14 +18,14 @@
     </dependencySets>
     <fileSets>
       <fileSet>
-        <outputDirectory>/</outputDirectory>
+        <outputDirectory>/elasticsearch/</outputDirectory>
         <includes>
           <include>LICENSE.txt</include>
         </includes>
       </fileSet>
       <fileSet>
         <directory>src/main/resources</directory>
-        <outputDirectory>/</outputDirectory>
+        <outputDirectory>/elasticsearch/</outputDirectory>
         <includes>
           <include>plugin-descriptor.properties</include>
         </includes>


### PR DESCRIPTION
This fixes the issue where `elasticsearch-plugin install`
complains about the zip file not being a valid plugin (when installed through a `file://` URL to the ZIP file).