### PR TITLE
HZN-1255: push RPM to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,27 @@ jobs:
           command: |
             mvn -s .circleci.settings.xml -DskipTests deploy
 
+      - restore_cache:
+          keys:
+          - pip-cache-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - pip-cache-
+
+      - run:
+          name: Install AWS client
+          command: |
+            pip install awscli --upgrade --user
+
+      - save_cache:
+          paths:
+            - ~/.cache/pip
+          key: pip-cache-{{ checksum "pom.xml" }}
+
+      - run:
+          name: Deploy the RPM to S3
+          command: |
+            aws s3 sync target/rpm/elasticsearch-drift-plugin/RPMS/noarch/ s3://opennms-circleci-resources/elasticsearch-drift-plugin/
+
 workflows:
   version: 2
   build-deploy:
@@ -93,4 +114,5 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only:
+               - master

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build-eclipse/
 nb-configuration.xml
 nbactions.xml
 
+# vim
+.*.swp
+
 # gradle stuff
 .gradle/
 build/

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -26,7 +26,7 @@
         </includes>
       </fileSet>
       <fileSet>
-        <directory>src/main/resources</directory>
+        <directory>target/classes/</directory>
         <outputDirectory>/elasticsearch/</outputDirectory>
         <includes>
           <include>plugin-descriptor.properties</include>


### PR DESCRIPTION
This PR adds a CircleCI config to push the built RPM to AWS.  The project is already pre-configured for the AWS credentials so it should work as soon as this is merged.

On the client side I have things set up to auto-sync files that go into that S3 container into their respective directories in `develop/common` in the yum repository.  It only syncs things with `SNAPSHOT` in the revision, and deletes all but the latest snapshot for each version (determined with `rpm -q` queries) both locally and in the s3 container.

It also includes a build fix for the .zip file containing the `plugin-descriptor.properties` file.