### PR TITLE
HZN-1310: Add Debian package build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       - run:
-          name: Install RPM
-          command: sudo apt-get update; sudo apt-get install rpm
+          name: Install Packaging Dependencies
+          command: sudo apt-get update; sudo apt-get install rpm build-essential
 
       - run:
           name: Run the tests
@@ -103,6 +103,11 @@ jobs:
           name: Deploy the RPM to S3
           command: |
             aws s3 sync target/rpm/elasticsearch-drift-plugin/RPMS/noarch/ s3://opennms-circleci-resources/elasticsearch-drift-plugin/
+
+      - run:
+          name: Deploy the Deb file to S3
+          command: |
+            aws s3 sync target/releases/*.deb s3://opennms-circleci-resources/elasticsearch-drift-plugin/
 
 workflows:
   version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <targetDir>${project.build.directory}/releases</targetDir>
                         <packageVersion>${project.version}</packageVersion>
                         <packageRevision>1</packageRevision>
                         <packageSection>contrib/net</packageSection>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
                 <plugin>
                     <groupId>net.sf.debian-maven</groupId>
                     <artifactId>debian-maven-plugin</artifactId>
+                    <version>1.0.6</version>
                     <executions>
                         <execution>
                             <id>generate-deb</id>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <elasticsearch.version>6.2.4</elasticsearch.version>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <rpmRelease>0.${maven.build.timestamp}.SNAPSHOT</rpmRelease>
+        <packageSummary>Time series aggregation for flow records in Elasticsearch</packageSummary>
     </properties>
 
     <dependencies>
@@ -76,6 +77,38 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>net.sf.debian-maven</groupId>
+                    <artifactId>debian-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>generate-deb</id>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <packageVersion>${project.version}</packageVersion>
+                        <packageRevision>1</packageRevision>
+                        <packageSection>contrib/net</packageSection>
+                        <packageTitle>${packageSummary}</packageTitle>
+                        <packageDescription>${packageDescription}</packageDescription>
+                        <packageDescription>This plugin provides a new aggregation function proportional_sum that can be used to
+ group documents that contain a date range into multiple buckets, and calculate a sum
+ on a per bucket basis using a ratio that is proportional to the range of time in which
+ the document spent in that bucket.
+ .
+ This aggregation function behaves like a hybrid of both the Metrics and Bucket type
+ aggregations since we both create buckets and calculate a new metric.</packageDescription>
+                        <packageDependencies>
+                            <packageDependency>elasticsearch (= ${elasticsearch.version})</packageDependency>
+                        </packageDependencies>
+                        <excludeAllArtifacts>true</excludeAllArtifacts>
+                        <excludeAllDependencies>true</excludeAllDependencies>
+                        <includeAttachedArtifacts>false</includeAttachedArtifacts>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>rpm-maven-plugin</artifactId>
                     <version>2.1.5</version>
@@ -88,7 +121,7 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <summary>Time series aggregation for flow records in Elasticsearch</summary>
+                        <summary>${packageSummary}</summary>
                         <description>This plugin provides a new aggregation function proportional_sum that can be used to
 group documents that contain a date range into multiple buckets, and calculate a sum
 on a per bucket basis using a ratio that is proportional to the range of time in which
@@ -114,22 +147,8 @@ aggregations since we both create buckets and calculate a new metric.</descripti
                             <mapping>
                                 <directory>/usr/share/elasticsearch/plugins/drift</directory>
                                 <sources>
-                                    <source><location>target/classes/plugin-descriptor.properties</location></source>
+                                    <source><location>target/releases/${project.name}-${project.version}/elasticsearch/</location></source>
                                 </sources>
-                            </mapping>
-                            <mapping>
-                                <directory>/usr/share/elasticsearch/plugins/drift</directory>
-                                <sources>
-                                    <source><location>target/${project.name}-${project.version}.jar</location></source>
-                                </sources>
-                            </mapping>
-                            <mapping>
-                                <directory>/usr/share/elasticsearch/plugins/drift</directory>
-                                <dependency>
-                                    <includes>
-                                        <include>org.elasticsearch.plugin:aggs-matrix-stats-client</include>
-                                    </includes>
-                                </dependency>
                             </mapping>
                             <mapping>
                                 <directory>/usr/share/doc/elasticsearch-drift-plugin</directory>
@@ -183,6 +202,56 @@ aggregations since we both create buckets and calculate a new metric.</descripti
                         <goals>
                             <goal>single</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-filtered-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>copy-deb-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/target/deb/usr/share/elasticsearch/plugins/drift/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>target/releases/${project.name}-${project.version}/elasticsearch/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-deb-docs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/target/deb/usr/share/doc/${project.name}/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}</directory>
+                                    <includes>
+                                        <include>LICENSE.txt</include>
+                                        <include>README.md</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -247,7 +316,7 @@ aggregations since we both create buckets and calculate a new metric.</descripti
             </build>
         </profile>
         <profile>
-            <id>build.rpms.usr.clocal</id>
+            <id>build.rpms.usr.local</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
                 <file>
@@ -259,6 +328,23 @@ aggregations since we both create buckets and calculate a new metric.</descripti
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build.debs</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>/usr/bin/dpkg-buildpackage</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.sf.debian-maven</groupId>
+                        <artifactId>debian-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -3,6 +3,7 @@
     <id>plugin</id>
     <formats>
         <format>zip</format>
+        <format>dir</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>


### PR DESCRIPTION
This PR adds support for building `.deb` files from the maven build if `dpkg-buildpackage` exists.